### PR TITLE
Fix new user missing authorized keys

### DIFF
--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -2,4 +2,4 @@
 
 package config
 
-const version = "v0.9.5"
+const version = "v0.9.6"


### PR DESCRIPTION
For a newly created user, the `<user_home>/.ssh/authorized_keys` file is missing at the beginning, attempting to copy the file attribute (mostly selinux context) from the non-exist file will result in errors and cause failure for registering the keys. 
