### PR TITLE
check version should not check against github

### DIFF
--- a/scripts/check_version.sh
+++ b/scripts/check_version.sh
@@ -28,9 +28,6 @@ function main() {
   if spaces_version_exist "${latest_ver}"; then
     abort "${latest_ver} already deployed"
   fi
-  if github_release_exist "${latest_ver}"; then
-    abort "${latest_ver} already released"
-  fi
   echo "Okay to deployed"
 }
 


### PR DESCRIPTION
There was a bug:
When a branch with a new version created is merged to main, check_version will report "version already exists" when attempting to deploy. 
We should use spaces as the only source of truth for determining whether a version is deployed or not, therefore removing the github tag check from check_version.sh

This PR does not involve any changes to the agent, so no new version or deployment needed.