### PR TITLE
refactor update.sh: light-weight check version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased](https://github.com/digitalocean/droplet-agent/tree/HEAD)
 
+## [1.1.1](https://github.com/digitalocean/droplet-agent/tree/1.1.1) (2021-11-24)
+### Updated
+- Refactored the update script to consume less CPU when checking for newer version.
+
+### Related PRs
+- refactor update.sh: light-weight check version [\#43](https://github.com/digitalocean/droplet-agent/pull/43) ([house-lee](https://github.com/house-lee))
+
 ## [1.1.0](https://github.com/digitalocean/droplet-agent/tree/1.1.0) (2021-10-28)
 ### Added
 - Support for custom sshd port. If the sshd service is running on a port different from the default one (22), the agent 

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -2,4 +2,4 @@
 
 package config
 
-const version = "v1.1.0"
+const version = "v1.1.1"

--- a/packaging/scripts/update.sh
+++ b/packaging/scripts/update.sh
@@ -1,20 +1,112 @@
-#!/bin/bash
+#!/bin/sh
 # vim: noexpandtab
+
+set -ue
+
+SVC_NAME="droplet-agent"
+
+REPO_HOST=""
+PKG_PATTERN=""
+ARCH=""
+ARCH_ALIAS=""
+LATEST_VER="-"
+LOCAL_VER=""
 
 main() {
   # add some jitter to prevent overloading the remote repo server
-  delay=$((RANDOM % 120))
+  delay=$((RANDOM % 900))
   echo "Waiting ${delay} seconds"
   sleep ${delay}
 
+  check_arch
   if command -v apt-get 2 &>/dev/null; then
-    export DEBIAN_FRONTEND="noninteractive"
-    apt-get -qq update -o Dir::Etc::SourceParts=/dev/null -o APT::Get::List-Cleanup=no -o Dir::Etc::SourceList="sources.list.d/droplet-agent.list"
-    apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -qq install -y --only-upgrade droplet-agent
+    platform="deb"
+    do_update=update_deb
   elif command -v yum 2 &>/dev/null; then
-    yum -q -y --disablerepo="*" --enablerepo="droplet-agent" makecache
-    yum -q -y update droplet-agent
+    platform="rpm"
+    do_update=update_rpm
   fi
+  prepare "${platform}"
+  find_latest_pkg
+  if [ "${LOCAL_VER}" = "${LATEST_VER}" ]; then
+    echo "No need to update"
+    exit 0
+  fi
+  ${do_update}
+}
+update_deb() {
+  export DEBIAN_FRONTEND="noninteractive"
+  apt-get -qq update -o Dir::Etc::SourceParts=/dev/null -o APT::Get::List-Cleanup=no -o Dir::Etc::SourceList="sources.list.d/${SVC_NAME}.list"
+  apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -qq install -y --only-upgrade ${SVC_NAME}
+}
+
+update_rpm() {
+  yum -q -y --disablerepo="*" --enablerepo="${SVC_NAME}" makecache
+  yum -q -y update ${SVC_NAME}
+}
+
+check_arch() {
+  echo -n "Checking architecture support..."
+  case $(uname -m) in
+  i386 | i686)
+    ARCH="i386"
+    ARCH_ALIAS="i386"
+    ;;
+  x86_64)
+    ARCH="x86_64"
+    ARCH_ALIAS="amd64"
+    ;;
+  *) not_supported ;;
+  esac
+  echo "OK"
+}
+
+prepare() {
+  echo "Preparing to check for update"
+  platform=${1:-}
+  [ -z "${platform}" ] && abort "Destination repository is required. Usage: prepare <platform>"
+  case "${platform}" in
+  rpm)
+    LOCAL_VER=$(rpm -q ${SVC_NAME} --qf '%{VERSION}')
+    url=$(grep baseurl <"/etc/yum.repos.d/${SVC_NAME}.repo" | cut -f 2 -d=)
+    url=$(echo "${url}/${SVC_NAME}." | sed -e "s|\$basearch|${ARCH}|g")
+    ;;
+  deb)
+    LOCAL_VER=$(dpkg -s ${SVC_NAME} | grep Version | cut -f 2 -d: | tr -d '[:space:]')
+    url=$(cut -f 3 -d' ' <"/etc/apt/sources.list.d/${SVC_NAME}.list")
+    url="${url}/pool/main/main/d/${SVC_NAME}/${SVC_NAME}_"
+    ;;
+  esac
+  REPO_HOST=$(echo "${url}" | grep "/" | cut -d"/" -f1-3)
+  PKG_PATTERN=$(echo "${url}" | grep "/" | cut -d"/" -f4-)
+  echo "Package Host: ${REPO_HOST}"
+  echo "Package Path: ${PKG_PATTERN}"
+  echo "Local Version:${LOCAL_VER}"
+}
+
+find_latest_pkg() {
+  echo -n "Checking Latest Version..."
+  repo_tree=$(curl -sSL "${REPO_HOST}" || wget -qO- "${REPO_HOST}")
+  files=$(echo "${repo_tree}" | grep -oP '(?<=Key>'"${PKG_PATTERN}"')[^<]+' | tr ' ' '\n')
+  sorted_files=$(echo "${files}" | sort -V)
+  LATEST_VER=$(echo "${sorted_files}" | tail -1 | grep -oP '\d.\d.\d')
+  echo "${LATEST_VER}"
+}
+
+not_supported() {
+  cat <<-EOF
+
+	This script does not support the OS/Distribution on this machine.
+	If you feel that this is an error contact support@digitalocean.com
+
+	EOF
+  exit 2
+}
+
+# abort with an error message
+abort() {
+  echo "ERROR: $1" >/dev/stderr
+  exit 1
 }
 
 main

--- a/packaging/scripts/update.sh
+++ b/packaging/scripts/update.sh
@@ -14,7 +14,7 @@ LOCAL_VER=""
 
 main() {
   # add some jitter to prevent overloading the remote repo server
-  delay=$(( RANDOM % 3 ))
+  delay=$(( RANDOM % 900 ))
   echo "Waiting ${delay} seconds"
   sleep ${delay}
 


### PR DESCRIPTION
Previously we were leveraging `apt-get update` to check if there's any newer version presented and perform the update if necessary. However, `apt-get` can cause unwanted CPU spike. We refactored the update.sh to check version against the repo tree directly and only perform `apt-get` when need to upgrade. 