### PR TITLE
Pvaccaro/skip invalid keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/digitalocean/droplet-agent/tree/HEAD)
 
+## [1.2.1](https://github.com/digitalocean/droplet-agent/tree/1.2.1) (2022-03-28)
+### Updated
+- Added logic to handle skipping invalid keys while continue to process valid keys
+
+
 ## [1.2.0](https://github.com/digitalocean/droplet-agent/tree/1.2.0) (2022-02-03)
 ### Updated
 - Add support for managing SSH Keys on a droplet. If a droplet is configured with one or more SSH Keys through 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ## [1.2.1](https://github.com/digitalocean/droplet-agent/tree/1.2.1) (2022-03-28)
 ### Updated
-- Added logic to handle skipping invalid keys while continue to process valid keys
-
+- Added support for validating SSH Keys on a key-by-key basis.
+- Updating SSH Keys will now partially succeed with an input of a mix of valid and invalid SSHKeys.
 
 ## [1.2.0](https://github.com/digitalocean/droplet-agent/tree/1.2.0) (2022-02-03)
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 - Now, instead of failing at the first invalid SSH key, we continue processing in case there are valid SSH keys in the input list.
 - This behavior is accomplished by skipping invalid keys, and only processing the valid keys.
 
+### Bug fixed
+- Fixed a bug that can unexpectedly extend the expiry time of a temporary ssh key
+
+### Related PRs
+- Skip invalid keys [\#49](https://github.com/digitalocean/droplet-agent/pull/49)
+- Should not change expired time if key unchanged [\#50](https://github.com/digitalocean/droplet-agent/pull/50)
+
 ## [1.2.0](https://github.com/digitalocean/droplet-agent/tree/1.2.0) (2022-02-03)
 ### Updated
 - Add support for managing SSH Keys on a droplet. If a droplet is configured with one or more SSH Keys through 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ## [1.2.1](https://github.com/digitalocean/droplet-agent/tree/1.2.1) (2022-03-28)
 ### Updated
-- Added support for validating SSH Keys on a key-by-key basis.
-- Updating SSH Keys will now partially succeed with an input of a mix of valid and invalid SSHKeys.
+- Update ssh keys will ignore invalid keys.
+- We noticed that some keys configured for a droplet may become deprecated by OpenSSH, which causes validation of those keys to fail. 
+- We relaxed the requirement of input key validation from all input keys being valid, to at-least one input key being valid.
+- This behavior is accomplished by skipping invalid keys, and only processing the valid keys.
 
 ## [1.2.0](https://github.com/digitalocean/droplet-agent/tree/1.2.0) (2022-02-03)
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ## [1.2.1](https://github.com/digitalocean/droplet-agent/tree/1.2.1) (2022-03-28)
 ### Updated
 - Update ssh keys will ignore invalid keys.
-- We noticed that some keys configured for a droplet may become deprecated by OpenSSH, which causes validation of those keys to fail. 
-- We relaxed the requirement of input key validation from all input keys being valid, to at-least one input key being valid.
+- We noticed that some keys configured for a droplet may become deprecated by OpenSSH, which causes validation of those keys to fail.
+- Now, instead of failing at the first invalid SSH key, we continue processing in case there are valid SSH keys in the input list.
 - This behavior is accomplished by skipping invalid keys, and only processing the valid keys.
 
 ## [1.2.0](https://github.com/digitalocean/droplet-agent/tree/1.2.0) (2022-02-03)

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -2,4 +2,4 @@
 
 package config
 
-const version = "v1.2.0"
+const version = "v1.2.1"

--- a/internal/sysaccess/sshmgr.go
+++ b/internal/sysaccess/sshmgr.go
@@ -133,7 +133,9 @@ func (s *SSHManager) UpdateKeys(keys []*SSHKey) (retErr error) {
 	updatedKeys := make(map[string][]*SSHKey)
 	for _, key := range keys {
 		if err := s.validateKey(key); err != nil {
-			return err
+			//invalid key, skip
+			log.Debug("invalid key, %s", err.Error())
+			continue
 		}
 		if _, ok := keyGroups[key.OSUser]; !ok {
 			keyGroups[key.OSUser] = make([]*SSHKey, 0, 1)

--- a/internal/sysaccess/sshmgr.go
+++ b/internal/sysaccess/sshmgr.go
@@ -134,7 +134,7 @@ func (s *SSHManager) UpdateKeys(keys []*SSHKey) (retErr error) {
 	for _, key := range keys {
 		if err := s.validateKey(key); err != nil {
 			//invalid key, skip
-			log.Debug("invalid key, %s", err.Error())
+			log.Error("invalid key, %s", err.Error())
 			continue
 		}
 		if _, ok := keyGroups[key.OSUser]; !ok {

--- a/internal/sysaccess/sshmgr.go
+++ b/internal/sysaccess/sshmgr.go
@@ -148,11 +148,12 @@ func (s *SSHManager) UpdateKeys(keys []*SSHKey) (retErr error) {
 		}
 	}()
 
+	cleanKeys := s.removeExpiredKeys(s.cachedKeys)
 	for username, keys := range keyGroups {
-		if s.areSameKeys(keys, s.cachedKeys[username]) {
+		if s.areSameKeys(keys, cleanKeys[username]) {
 			//key not changed for the current user, skip
 			log.Debug("keys not changed for %s, skipped", username)
-			updatedKeys[username] = keys
+			updatedKeys[username] = cleanKeys[username]
 			continue
 		}
 		log.Debug("updating %d keys for %s", len(keys), username)
@@ -198,7 +199,7 @@ func (s *SSHManager) RemoveDOTTYKeys() error {
 					log.Info("os user [%s] no longer exists", u)
 					return nil
 				}
-				return fmt.Errorf("%w: failed to remove keys for user %s", err, user)
+				return fmt.Errorf("%w: failed to remove keys for user %s", err, u)
 			}
 			return nil
 		})

--- a/internal/sysaccess/sshmgr_test.go
+++ b/internal/sysaccess/sshmgr_test.go
@@ -4,12 +4,12 @@ package sysaccess
 
 import (
 	"errors"
-	"github.com/digitalocean/droplet-agent/internal/sysutil"
 	"reflect"
 	"testing"
 
 	"github.com/digitalocean/droplet-agent/internal/log"
 	"github.com/digitalocean/droplet-agent/internal/sysaccess/internal/mocks"
+	"github.com/digitalocean/droplet-agent/internal/sysutil"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang/mock/gomock"
@@ -309,7 +309,7 @@ func TestSSHManager_UpdateKeys(t *testing.T) {
 			},
 			[]*SSHKey{key1, key11, key21},
 			nil,
-			nil,
+			map[string][]*SSHKey{username1: {key11}},
 		},
 		{
 			"should group the keys by user and do not update keys for a user if unchanged",

--- a/internal/sysaccess/sshmgr_test.go
+++ b/internal/sysaccess/sshmgr_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/digitalocean/droplet-agent/internal/log"
 	"github.com/digitalocean/droplet-agent/internal/sysaccess/internal/mocks"
@@ -238,7 +239,7 @@ func TestSSHManager_parseSSHDConfig(t *testing.T) {
 
 func TestSSHManager_UpdateKeys(t *testing.T) {
 	log.Mute()
-
+	timeNow := time.Now()
 	username1 := "user1"
 	key1 := &SSHKey{
 		OSUser:    username1,
@@ -250,13 +251,20 @@ func TestSSHManager_UpdateKeys(t *testing.T) {
 		PublicKey: "public-key-11",
 		TTL:       123,
 	}
-
 	username2 := "user2"
 	key21 := &SSHKey{
 		OSUser:    username2,
 		PublicKey: "public-key-21",
 		TTL:       123,
+		expireAt:  timeNow.Add(time.Minute),
 	}
+	key21newExp := &SSHKey{
+		OSUser:    username2,
+		PublicKey: "public-key-21",
+		TTL:       123,
+		expireAt:  timeNow.Add(2 * time.Minute),
+	}
+
 	key22 := &SSHKey{
 		OSUser:    username2,
 		PublicKey: "public-key-22",
@@ -287,23 +295,36 @@ func TestSSHManager_UpdateKeys(t *testing.T) {
 			nil,
 		},
 		{
-			"should removed expired keys from the cached keys before proceeding and return error when ALL of the keys are invalid",
+			"should attempt to clear the keys if  ALL of the keys are invalid",
 			func(sshMgr *SSHManager, sshHpr *MocksshHelper, updater *MockauthorizedKeysFileUpdater) {
+				oldCachedKeys := map[string][]*SSHKey{
+					username1: {key11},
+					username2: {key22},
+				}
+				sshMgr.cachedKeys = oldCachedKeys
 				sshHpr.EXPECT().validateKey(key1).Return(invalidKeyErr)
 				sshHpr.EXPECT().validateKey(key11).Return(invalidKeyErr)
 				sshHpr.EXPECT().validateKey(key21).Return(invalidKeyErr)
+
+				sshHpr.EXPECT().removeExpiredKeys(oldCachedKeys).Return(oldCachedKeys)
+
+				updater.EXPECT().updateAuthorizedKeysFile(username1, []*SSHKey{}).Return(nil)
+				updater.EXPECT().updateAuthorizedKeysFile(username2, []*SSHKey{}).Return(nil)
 			},
 			[]*SSHKey{key1, key11, key21},
-			invalidKeyErr,
 			nil,
+			map[string][]*SSHKey{},
 		},
 		{
-			"should removed expired keys from the cached keys before proceeding and continue processing when SOME of the keys are invalid",
+			"should continue processing when SOME of the keys are invalid",
 			func(sshMgr *SSHManager, sshHpr *MocksshHelper, updater *MockauthorizedKeysFileUpdater) {
 				sshHpr.EXPECT().validateKey(key1).Return(invalidKeyErr)
 				sshHpr.EXPECT().validateKey(key11).Return(nil)
 				sshHpr.EXPECT().areSameKeys([]*SSHKey{key11}, nil).
 					Return(false)
+
+				sshHpr.EXPECT().removeExpiredKeys(nil).Return(nil)
+
 				updater.EXPECT().updateAuthorizedKeysFile(username1, []*SSHKey{key11}).Return(nil)
 				sshHpr.EXPECT().validateKey(key21).Return(invalidKeyErr)
 			},
@@ -314,18 +335,20 @@ func TestSSHManager_UpdateKeys(t *testing.T) {
 		{
 			"should group the keys by user and do not update keys for a user if unchanged",
 			func(sshMgr *SSHManager, sshHpr *MocksshHelper, updater *MockauthorizedKeysFileUpdater) {
-				sshMgr.cachedKeys = map[string][]*SSHKey{
+				oldCachedKeys := map[string][]*SSHKey{
 					username1: {key1},
 					username2: {key21, key22},
 				}
+				sshMgr.cachedKeys = oldCachedKeys
 				sshHpr.EXPECT().validateKey(gomock.Any()).Return(nil).Times(3)
+				sshHpr.EXPECT().removeExpiredKeys(oldCachedKeys).Return(oldCachedKeys)
 				sshHpr.EXPECT().areSameKeys([]*SSHKey{key11}, sshMgr.cachedKeys[username1]).
 					Return(false)
 				updater.EXPECT().updateAuthorizedKeysFile(username1, []*SSHKey{key11}).Return(nil)
-				sshHpr.EXPECT().areSameKeys([]*SSHKey{key21, key22}, sshMgr.cachedKeys[username2]).
+				sshHpr.EXPECT().areSameKeys([]*SSHKey{key21newExp, key22}, sshMgr.cachedKeys[username2]).
 					Return(true)
 			},
-			[]*SSHKey{key11, key21, key22},
+			[]*SSHKey{key11, key21newExp, key22},
 			nil,
 			map[string][]*SSHKey{
 				username1: {key11},
@@ -335,10 +358,12 @@ func TestSSHManager_UpdateKeys(t *testing.T) {
 		{
 			"should not cache keys for a user if failed to update key",
 			func(sshMgr *SSHManager, sshHpr *MocksshHelper, updater *MockauthorizedKeysFileUpdater) {
-				sshMgr.cachedKeys = map[string][]*SSHKey{
+				oldCachedKeys := map[string][]*SSHKey{
 					username1: {key1},
 				}
+				sshMgr.cachedKeys = oldCachedKeys
 				sshHpr.EXPECT().validateKey(gomock.Any()).Return(nil)
+				sshHpr.EXPECT().removeExpiredKeys(oldCachedKeys).Return(oldCachedKeys)
 				sshHpr.EXPECT().areSameKeys([]*SSHKey{key11}, sshMgr.cachedKeys[username1]).
 					Return(false)
 				updater.EXPECT().updateAuthorizedKeysFile(username1, []*SSHKey{key11}).Return(failedUpdateErr)
@@ -350,10 +375,12 @@ func TestSSHManager_UpdateKeys(t *testing.T) {
 		{
 			"should work if metadata returned keys for a new user",
 			func(sshMgr *SSHManager, sshHpr *MocksshHelper, updater *MockauthorizedKeysFileUpdater) {
-				sshMgr.cachedKeys = map[string][]*SSHKey{
+				oldCachedKeys := map[string][]*SSHKey{
 					username1: {key1},
 				}
+				sshMgr.cachedKeys = oldCachedKeys
 				sshHpr.EXPECT().validateKey(gomock.Any()).Return(nil).Times(3)
+				sshHpr.EXPECT().removeExpiredKeys(oldCachedKeys).Return(oldCachedKeys)
 
 				sshHpr.EXPECT().areSameKeys([]*SSHKey{key1}, sshMgr.cachedKeys[username1]).
 					Return(true)
@@ -372,11 +399,13 @@ func TestSSHManager_UpdateKeys(t *testing.T) {
 		{
 			"should work if metadata removed keys for an existing user",
 			func(sshMgr *SSHManager, sshHpr *MocksshHelper, updater *MockauthorizedKeysFileUpdater) {
-				sshMgr.cachedKeys = map[string][]*SSHKey{
+				oldCachedKeys := map[string][]*SSHKey{
 					username1: {key1},
 					username2: {key21, key22},
 				}
+				sshMgr.cachedKeys = oldCachedKeys
 				sshHpr.EXPECT().validateKey(gomock.Any()).Return(nil)
+				sshHpr.EXPECT().removeExpiredKeys(oldCachedKeys).Return(oldCachedKeys)
 				sshHpr.EXPECT().areSameKeys([]*SSHKey{key1}, []*SSHKey{key1}).
 					Return(true)
 
@@ -391,12 +420,14 @@ func TestSSHManager_UpdateKeys(t *testing.T) {
 		{
 			"should proceed if encountered user not found error when removing keys for an user",
 			func(sshMgr *SSHManager, sshHpr *MocksshHelper, updater *MockauthorizedKeysFileUpdater) {
-				sshMgr.cachedKeys = map[string][]*SSHKey{
+				oldCachedKeys := map[string][]*SSHKey{
 					username1: {key1},
 					username2: {key21, key22},
 					username3: {key31},
 				}
+				sshMgr.cachedKeys = oldCachedKeys
 				sshHpr.EXPECT().validateKey(gomock.Any()).Return(nil)
+				sshHpr.EXPECT().removeExpiredKeys(oldCachedKeys).Return(oldCachedKeys)
 				sshHpr.EXPECT().areSameKeys([]*SSHKey{key1}, []*SSHKey{key1}).
 					Return(true)
 
@@ -412,12 +443,14 @@ func TestSSHManager_UpdateKeys(t *testing.T) {
 		{
 			"should keep the keys for a user in cache if failed to remove the keys from fs",
 			func(sshMgr *SSHManager, sshHpr *MocksshHelper, updater *MockauthorizedKeysFileUpdater) {
-				sshMgr.cachedKeys = map[string][]*SSHKey{
+				oldCachedKeys := map[string][]*SSHKey{
 					username1: {key1},
 					username2: {key21, key22},
 					username3: {key31},
 				}
+				sshMgr.cachedKeys = oldCachedKeys
 				sshHpr.EXPECT().validateKey(gomock.Any()).Return(nil)
+				sshHpr.EXPECT().removeExpiredKeys(oldCachedKeys).Return(oldCachedKeys)
 				sshHpr.EXPECT().areSameKeys([]*SSHKey{key1}, []*SSHKey{key1}).
 					Return(true)
 
@@ -429,6 +462,53 @@ func TestSSHManager_UpdateKeys(t *testing.T) {
 			map[string][]*SSHKey{
 				username1: {key1},
 				username2: {key21, key22},
+			},
+		},
+		{
+			"should work if re-add a key that is already expired",
+			func(sshMgr *SSHManager, sshHpr *MocksshHelper, updater *MockauthorizedKeysFileUpdater) {
+				oldCachedKeys := map[string][]*SSHKey{
+					username2: {key21},
+				}
+				sshMgr.cachedKeys = oldCachedKeys
+				sshHpr.EXPECT().validateKey(gomock.Any()).Return(nil)
+				sshHpr.EXPECT().removeExpiredKeys(oldCachedKeys).Return(map[string][]*SSHKey{})
+				sshHpr.EXPECT().areSameKeys([]*SSHKey{key21newExp}, nil).
+					Return(false)
+
+				updater.EXPECT().updateAuthorizedKeysFile(username2, []*SSHKey{key21newExp}).Return(nil)
+			},
+			[]*SSHKey{key21newExp},
+			nil,
+			map[string][]*SSHKey{
+				username2: {key21newExp},
+			},
+		},
+		{
+			"in the case of cached keys expired, should still attempt to clean up the keys of a user that no longer has active keys",
+			func(sshMgr *SSHManager, sshHpr *MocksshHelper, updater *MockauthorizedKeysFileUpdater) {
+				oldCachedKeys := map[string][]*SSHKey{
+					username2: {key21},
+				}
+				sshMgr.cachedKeys = oldCachedKeys
+				sshHpr.EXPECT().validateKey(gomock.Any()).Return(nil).AnyTimes()
+				sshHpr.EXPECT().removeExpiredKeys(oldCachedKeys).Return(map[string][]*SSHKey{})
+
+
+				sshHpr.EXPECT().areSameKeys([]*SSHKey{key1}, nil).
+					Return(false)
+				updater.EXPECT().updateAuthorizedKeysFile(username1, []*SSHKey{key1}).Return(nil)
+				sshHpr.EXPECT().areSameKeys([]*SSHKey{key31}, nil).
+					Return(false)
+				updater.EXPECT().updateAuthorizedKeysFile(username3, []*SSHKey{key31}).Return(nil)
+
+				updater.EXPECT().updateAuthorizedKeysFile(username2, []*SSHKey{}).Return(nil)
+			},
+			[]*SSHKey{key1, key31},
+			nil,
+			map[string][]*SSHKey{
+				username1: {key1},
+				username3: {key31},
 			},
 		},
 	}

--- a/scripts/check_version.sh
+++ b/scripts/check_version.sh
@@ -28,7 +28,7 @@ function main() {
   if spaces_version_exist "${latest_ver}"; then
     abort "${latest_ver} already deployed"
   fi
-  echo "Okay to deployed"
+  echo "Okay to deploy"
 }
 
 main "$@"


### PR DESCRIPTION
What've been done:
- [x] Added support for validating SSH Keys on a key-by-key basis. Updating SSH Keys will now partially succeed with an input of a mix of valid and invalid SSHKeys.