### PR TITLE
Should not change expired time if key unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/digitalocean/droplet-agent/tree/HEAD)
 
+## [1.2.1](https://github.com/digitalocean/droplet-agent/tree/1.2.1) (2022-03-28)
+### Updated
+- Added logic to handle skipping invalid keys while continue to process valid keys
+
+
 ## [1.2.0](https://github.com/digitalocean/droplet-agent/tree/1.2.0) (2022-02-03)
 ### Updated
 - Add support for managing SSH Keys on a droplet. If a droplet is configured with one or more SSH Keys through 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ## [1.2.1](https://github.com/digitalocean/droplet-agent/tree/1.2.1) (2022-03-28)
 ### Updated
-- Added logic to handle skipping invalid keys while continue to process valid keys
-
+- Added support for validating SSH Keys on a key-by-key basis.
+- Updating SSH Keys will now partially succeed with an input of a mix of valid and invalid SSHKeys.
 
 ## [1.2.0](https://github.com/digitalocean/droplet-agent/tree/1.2.0) (2022-02-03)
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ## [1.2.1](https://github.com/digitalocean/droplet-agent/tree/1.2.1) (2022-03-28)
 ### Updated
-- Added support for validating SSH Keys on a key-by-key basis.
-- Updating SSH Keys will now partially succeed with an input of a mix of valid and invalid SSHKeys.
+- Update ssh keys will ignore invalid keys.
+- We noticed that some keys configured for a droplet may become deprecated by OpenSSH, which causes validation of those keys to fail. 
+- We relaxed the requirement of input key validation from all input keys being valid, to at-least one input key being valid.
+- This behavior is accomplished by skipping invalid keys, and only processing the valid keys.
 
 ## [1.2.0](https://github.com/digitalocean/droplet-agent/tree/1.2.0) (2022-02-03)
 ### Updated

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -2,4 +2,4 @@
 
 package config
 
-const version = "v1.2.0"
+const version = "v1.2.1"

--- a/internal/sysaccess/sshmgr.go
+++ b/internal/sysaccess/sshmgr.go
@@ -133,7 +133,9 @@ func (s *SSHManager) UpdateKeys(keys []*SSHKey) (retErr error) {
 	updatedKeys := make(map[string][]*SSHKey)
 	for _, key := range keys {
 		if err := s.validateKey(key); err != nil {
-			return err
+			//invalid key, skip
+			log.Debug("invalid key, %s", err.Error())
+			continue
 		}
 		if _, ok := keyGroups[key.OSUser]; !ok {
 			keyGroups[key.OSUser] = make([]*SSHKey, 0, 1)

--- a/internal/sysaccess/sshmgr.go
+++ b/internal/sysaccess/sshmgr.go
@@ -134,7 +134,7 @@ func (s *SSHManager) UpdateKeys(keys []*SSHKey) (retErr error) {
 	for _, key := range keys {
 		if err := s.validateKey(key); err != nil {
 			//invalid key, skip
-			log.Debug("invalid key, %s", err.Error())
+			log.Error("invalid key, %s", err.Error())
 			continue
 		}
 		if _, ok := keyGroups[key.OSUser]; !ok {

--- a/internal/sysaccess/sshmgr.go
+++ b/internal/sysaccess/sshmgr.go
@@ -152,7 +152,7 @@ func (s *SSHManager) UpdateKeys(keys []*SSHKey) (retErr error) {
 		if s.areSameKeys(keys, s.cachedKeys[username]) {
 			//key not changed for the current user, skip
 			log.Debug("keys not changed for %s, skipped", username)
-			updatedKeys[username] = keys
+			updatedKeys[username] = s.cachedKeys[username]
 			continue
 		}
 		log.Debug("updating %d keys for %s", len(keys), username)

--- a/internal/sysaccess/sshmgr_test.go
+++ b/internal/sysaccess/sshmgr_test.go
@@ -4,12 +4,12 @@ package sysaccess
 
 import (
 	"errors"
-	"github.com/digitalocean/droplet-agent/internal/sysutil"
 	"reflect"
 	"testing"
 
 	"github.com/digitalocean/droplet-agent/internal/log"
 	"github.com/digitalocean/droplet-agent/internal/sysaccess/internal/mocks"
+	"github.com/digitalocean/droplet-agent/internal/sysutil"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang/mock/gomock"
@@ -309,7 +309,7 @@ func TestSSHManager_UpdateKeys(t *testing.T) {
 			},
 			[]*SSHKey{key1, key11, key21},
 			nil,
-			nil,
+			map[string][]*SSHKey{username1: {key11}},
 		},
 		{
 			"should group the keys by user and do not update keys for a user if unchanged",


### PR DESCRIPTION
Previously, if the keys of a user aren't changed, we still update the cached keys, which resulted in the expired time of keys being unwillingly extended. This PR fixed that