### PR TITLE
Support dynamically enabling and disabling managed keys feature 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased](https://github.com/digitalocean/droplet-agent/tree/HEAD)
 
+## [1.2.3](https://github.com/digitalocean/droplet-agent/tree/1.2.3) (2022-06-16)
+### Updated
+- Droplet Agent now supports dynamically turning the managed ssh keys feature on and off. If the metadata of the droplet
+suggests that the droplet has the managed ssh keys feature turned on, droplet-agent will attempt to manage the keys that 
+are configured through DigitalOcean platform.
+- NOTES: Only keys configured through DigitalOcean platform will be managed by the droplet-agent. Such keys will be 
+marked in the authorized_keys file and should not be manually modified.
+
+### Related PRs
+- Support dynamically enabling and disabling managed keys feature [\#58](https://github.com/digitalocean/droplet-agent/pull/58)
+
 ## [1.2.2](https://github.com/digitalocean/droplet-agent/tree/1.2.2) (2022-05-31)
 ### Updated
 - Starting from [1.2.0](https://github.com/digitalocean/droplet-agent/tree/1.2.0), agent supports managing ssh keys for

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -2,4 +2,4 @@
 
 package config
 
-const version = "v1.2.2"
+const version = "v1.2.3"

--- a/internal/metadata/actioner/do_managed_keys_actioner.go
+++ b/internal/metadata/actioner/do_managed_keys_actioner.go
@@ -42,7 +42,7 @@ type doManagedKeysActioner struct {
 func (da *doManagedKeysActioner) do(metadata *metadata.Metadata) {
 	log.Info("[DO-Managed Keys Actioner] Metadata contains %d ssh keys and %d dotty keys", len(metadata.PublicKeys), len(metadata.DOTTYKeys))
 	sshKeys := make([]*sysaccess.SSHKey, 0, len(metadata.PublicKeys)+len(metadata.DOTTYKeys))
-	if metadata.ManagedKeysEnabled {
+	if metadata.ManagedKeysEnabled != nil && *metadata.ManagedKeysEnabled {
 		log.Info("[DO-Managed Keys Actioner] Attempting to update %d ssh keys and %d dotty keys", len(metadata.PublicKeys), len(metadata.DOTTYKeys))
 		da.sshMgr.EnableManagedDropletKeys()
 	} else {

--- a/internal/metadata/actioner/do_managed_keys_actioner_test.go
+++ b/internal/metadata/actioner/do_managed_keys_actioner_test.go
@@ -17,6 +17,7 @@ import (
 
 func Test_dottyKeysActioner_do(t *testing.T) {
 	log.Mute()
+	newBoolPtr := func(v bool) *bool { return &v }
 
 	validDOTTYKey1 := &sysaccess.SSHKey{
 		OSUser:     "root",
@@ -130,7 +131,7 @@ func Test_dottyKeysActioner_do(t *testing.T) {
 				sshMgr.EXPECT().UpdateKeys([]*sysaccess.SSHKey{}).Return(nil)
 			},
 			&metadata.Metadata{
-				ManagedKeysEnabled: true,
+				ManagedKeysEnabled: newBoolPtr(true),
 			},
 		},
 	}

--- a/internal/metadata/actioner/do_managed_keys_actioner_test.go
+++ b/internal/metadata/actioner/do_managed_keys_actioner_test.go
@@ -52,6 +52,7 @@ func Test_dottyKeysActioner_do(t *testing.T) {
 		{
 			"should skip invalid public keys",
 			func(sshMgr *mocks.MocksshManager, keyParser *mocks.MocksshKeyParser) {
+				sshMgr.EXPECT().DisableManagedDropletKeys()
 				gomock.InOrder(
 					keyParser.EXPECT().FromPublicKey("invalid-public-key").Return(nil, errors.New("oops")),
 					keyParser.EXPECT().FromPublicKey(validDropletKey1Str).Return(validDropletKey1, nil),
@@ -70,6 +71,7 @@ func Test_dottyKeysActioner_do(t *testing.T) {
 		{
 			"should skip invalid dotty keys",
 			func(sshMgr *mocks.MocksshManager, keyParser *mocks.MocksshKeyParser) {
+				sshMgr.EXPECT().DisableManagedDropletKeys()
 				gomock.InOrder(
 					keyParser.EXPECT().FromDOTTYKey("invalid-dotty-key").Return(nil, errors.New("oops")),
 					keyParser.EXPECT().FromDOTTYKey(validDOTTYKey1Str).Return(validDOTTYKey1, nil),
@@ -88,6 +90,7 @@ func Test_dottyKeysActioner_do(t *testing.T) {
 		{
 			"should combine public keys and dotty keys",
 			func(sshMgr *mocks.MocksshManager, keyParser *mocks.MocksshKeyParser) {
+				sshMgr.EXPECT().DisableManagedDropletKeys()
 				gomock.InOrder(
 					keyParser.EXPECT().FromPublicKey(validDropletKey1Str).Return(validDropletKey1, nil),
 					keyParser.EXPECT().FromDOTTYKey(validDOTTYKey1Str).Return(validDOTTYKey1, nil),
@@ -112,11 +115,22 @@ func Test_dottyKeysActioner_do(t *testing.T) {
 		{
 			"should allow to clear keys if metadata does not contain any valid keys",
 			func(sshMgr *mocks.MocksshManager, keyParser *mocks.MocksshKeyParser) {
+				sshMgr.EXPECT().DisableManagedDropletKeys()
 				sshMgr.EXPECT().UpdateKeys([]*sysaccess.SSHKey{})
 			},
 			&metadata.Metadata{
 				PublicKeys: []string{},
 				DOTTYKeys:  []string{},
+			},
+		},
+		{
+			"should turn on managed keys if specified",
+			func(sshMgr *mocks.MocksshManager, keyParser *mocks.MocksshKeyParser) {
+				sshMgr.EXPECT().EnableManagedDropletKeys()
+				sshMgr.EXPECT().UpdateKeys([]*sysaccess.SSHKey{}).Return(nil)
+			},
+			&metadata.Metadata{
+				ManagedKeysEnabled: true,
 			},
 		},
 	}

--- a/internal/metadata/actioner/internal/mocks/mocks.go
+++ b/internal/metadata/actioner/internal/mocks/mocks.go
@@ -34,6 +34,30 @@ func (m *MocksshManager) EXPECT() *MocksshManagerMockRecorder {
 	return m.recorder
 }
 
+// DisableManagedDropletKeys mocks base method.
+func (m *MocksshManager) DisableManagedDropletKeys() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DisableManagedDropletKeys")
+}
+
+// DisableManagedDropletKeys indicates an expected call of DisableManagedDropletKeys.
+func (mr *MocksshManagerMockRecorder) DisableManagedDropletKeys() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableManagedDropletKeys", reflect.TypeOf((*MocksshManager)(nil).DisableManagedDropletKeys))
+}
+
+// EnableManagedDropletKeys mocks base method.
+func (m *MocksshManager) EnableManagedDropletKeys() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "EnableManagedDropletKeys")
+}
+
+// EnableManagedDropletKeys indicates an expected call of EnableManagedDropletKeys.
+func (mr *MocksshManagerMockRecorder) EnableManagedDropletKeys() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableManagedDropletKeys", reflect.TypeOf((*MocksshManager)(nil).EnableManagedDropletKeys))
+}
+
 // RemoveDOTTYKeys mocks base method.
 func (m *MocksshManager) RemoveDOTTYKeys() error {
 	m.ctrl.T.Helper()

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -27,8 +27,9 @@ type Metadata struct {
 	// DOTTYKeys contains temporary ssh keys used in cases such as web console access
 	DOTTYKeys []string `json:"dotty_keys,omitempty"`
 	// DOTTYStatus represents the state of the dotty agent valid states are "installed", "running", or "stopped"
-	DOTTYStatus AgentStatus `json:"dotty_status,omitempty"`
-	SSHInfo     *SSHInfo    `json:"ssh_info,omitempty"`
+	DOTTYStatus        AgentStatus `json:"dotty_status,omitempty"`
+	SSHInfo            *SSHInfo    `json:"ssh_info,omitempty"`
+	ManagedKeysEnabled bool        `json:"managed_keys_enabled"`
 }
 
 // SSHInfo contains the information of the sshd service running on the droplet

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -29,7 +29,7 @@ type Metadata struct {
 	// DOTTYStatus represents the state of the dotty agent valid states are "installed", "running", or "stopped"
 	DOTTYStatus        AgentStatus `json:"dotty_status,omitempty"`
 	SSHInfo            *SSHInfo    `json:"ssh_info,omitempty"`
-	ManagedKeysEnabled bool        `json:"managed_keys_enabled"`
+	ManagedKeysEnabled *bool       `json:"managed_keys_enabled,omitempty"`
 }
 
 // SSHInfo contains the information of the sshd service running on the droplet

--- a/internal/sysaccess/ssh_helper_test.go
+++ b/internal/sysaccess/ssh_helper_test.go
@@ -450,7 +450,12 @@ func Test_sshHelperImpl_prepareAuthorizedKeys(t *testing.T) {
 				timeNow: func() time.Time {
 					return timeNow
 				},
-				manageDropletKeys: !tt.withoutManagedKeys,
+				mgr: &SSHManager{
+					manageDropletKeys: manageDropletKeysEnabled,
+				},
+			}
+			if tt.withoutManagedKeys {
+				s.mgr.manageDropletKeys = manageDropletKeysDisabled
 			}
 			if got := s.prepareAuthorizedKeys(tt.args.localKeys, tt.args.managedKeys); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("prepareAuthorizedKeys() = %v, want %v", got, tt.want)


### PR DESCRIPTION
Droplet Agent now supports dynamically turning the managed ssh keys feature on and off. If the metadata of the droplet
suggests that the droplet has the managed ssh keys feature turned on, droplet-agent will attempt to manage the keys that 
are configured through DigitalOcean platform.