### PR TITLE
update.sh check for newer keyring packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased](https://github.com/digitalocean/droplet-agent/tree/HEAD)
 
+## [1.2.4](https://github.com/digitalocean/droplet-agent/tree/1.2.4) (2022-09-21)
+### Updated
+- For Ubuntu & Debian droplets, the update script will now also check for newer keyring package as well to ensure a fast
+and smooth GPG key rotation
+
+### Related PRs
+- update.sh check for newer keyring packages [\#60](https://github.com/digitalocean/droplet-agent/pull/60)
+
 ## [1.2.3](https://github.com/digitalocean/droplet-agent/tree/1.2.3) (2022-06-16)
 ### Updated
 - Droplet Agent now supports dynamically turning the managed ssh keys feature on and off. If the metadata of the droplet

--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,16 @@ touch        = @touch $@
 cp           = @cp $< $@
 print        = @printf "\n:::::::::::::::: [$(shell date -u)] $@ ::::::::::::::::\n"
 now          = $(shell date -u)
-fpm          = @docker run --rm -i -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" -u $(shell id -u) digitalocean/fpm:latest
-shellcheck   = @docker run --rm -i -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" -u $(shell id -u) koalaman/shellcheck:v0.6.0
+fpm          = @docker run --platform linux/amd64 --rm -i -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" -u $(shell id -u) digitalocean/fpm:latest
+shellcheck   = @docker run --platform linux/amd64 --rm -i -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" -u $(shell id -u) koalaman/shellcheck:v0.6.0
 version_check = @./scripts/check_version.sh
-linter = docker run --rm -i -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" -e "GO111MODULE=on" -e "GOFLAGS=-mod=vendor" -e "XDG_CACHE_HOME=$(CURDIR)/target/.cache/go" \
+linter = docker run --platform linux/amd64 --rm -i -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" -e "GO111MODULE=on" -e "GOFLAGS=-mod=vendor" -e "XDG_CACHE_HOME=$(CURDIR)/target/.cache/go" \
 	-u $(shell id -u) golangci/golangci-lint:v1.39 \
 	golangci-lint run --skip-files=.*_test.go -D errcheck -E golint -E gosec -E gofmt
 
 go_docker_linux = golang:1.18.2
 ifeq ($(GOOS), linux)
-go = docker run --rm -i \
+go = docker run --platform linux/amd64 --rm -i \
 	-e "GOOS=$(GOOS)" \
 	-e "GOARCH=$(GOARCH)" \
 	-e "GOCACHE=$(CURDIR)/target/.cache/go" \
@@ -178,7 +178,7 @@ $(deb_package): $(base_linux_package)
 		-p $@ \
 		$<
 	# print information about the compiled deb package
-	@docker run --rm -i -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" ubuntu:xenial /bin/bash -c 'dpkg --info $@ && dpkg -c $@'
+	@docker run --platform linux/amd64 --rm -i -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" ubuntu:xenial /bin/bash -c 'dpkg --info $@ && dpkg -c $@'
 
 rpm: $(rpm_package)
 $(rpm_package): $(base_linux_package)
@@ -194,7 +194,7 @@ $(rpm_package): $(base_linux_package)
 		-p $@ \
 		$<
 	# print information about the compiled rpm package
-	@docker run --rm -i -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" centos:7 rpm -qilp $@
+	@docker run --platform linux/amd64 --rm -i -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" centos:7 rpm -qilp $@
 
 tar: $(tar_package)
 $(tar_package): $(base_linux_package)
@@ -208,7 +208,7 @@ $(tar_package): $(base_linux_package)
 		-p $@ \
 		$<
 	# print all files within the archive
-	@docker run --rm -i -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" ubuntu:xenial tar -ztvf $@
+	@docker run --platform linux/amd64 --rm -i -v "$(CURDIR):$(CURDIR)" -w "$(CURDIR)" ubuntu:xenial tar -ztvf $@
 
 ## mockgen: generates the mocks for the droplet agent service
 mockgen:

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -2,4 +2,4 @@
 
 package config
 
-const version = "v1.2.3"
+const version = "v1.2.4"

--- a/packaging/scripts/update.sh
+++ b/packaging/scripts/update.sh
@@ -45,7 +45,7 @@ update_deb() {
   echo "Updating ${SVC_NAME} deb package"
   export DEBIAN_FRONTEND="noninteractive"
   apt-get -qq update -o Dir::Etc::SourceParts=/dev/null -o APT::Get::List-Cleanup=no -o Dir::Etc::SourceList="sources.list.d/${SVC_NAME}.list"
-  apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -qq install -y --only-upgrade ${SVC_NAME}
+  apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -qq install -y --only-upgrade ${SVC_NAME} ${KEYRING_PKG}
 }
 
 update_rpm() {


### PR DESCRIPTION
Why do we need this change:
- Previously we are only checking whether there's newer agent being released, and will only attempt to update when there is a newer agent package.
- In the case of gpg key change, for droplets running Ubuntu or Debian, such keyring package doesn't necessary come with a newer release of the agent package, which may result in gpg key not being updated in time and causing signature verification errors. 