### PR TITLE
Use Lshortfile in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased](https://github.com/digitalocean/droplet-agent/tree/HEAD)
 
+
+## [1.2.5](https://github.com/digitalocean/droplet-agent/tree/1.2.5) (2023-02-28)
+### Updated
+- Use Lshortfile to only show filename and line number in logs
+
+### Related PRs
+- Use Lshortfile in logs [\#72](https://github.com/digitalocean/droplet-agent/pull/72)
+
 ## Support AlmaLinux (2022-10-06)
 ### Updated
 - Add support for installing the agent on AlmaLinux (NOTE: no new version is introduced as there are not any changes made to the binary)

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -2,4 +2,4 @@
 
 package config
 
-const version = "v1.2.4"
+const version = "v1.2.5"

--- a/internal/log/syslog.go
+++ b/internal/log/syslog.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	syslogFlags = log.Llongfile
+	syslogFlags = log.Lshortfile
 )
 
 var once sync.Once


### PR DESCRIPTION
Right now we are logging using `log.Llongfile` format which saves the absolute file path in the droplet-agent log. 
This can be confusing to the customer as the path is only meaningful in the build environment, and it doesn't exist in the droplet. 

We should use `log.Lshortfile` to only include the file name and line number that generates the log. 