### PR TITLE
Fixed Improper Privilege Management Incorrect privilege reporting in …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
+	golang.org/x/sys v0.1.0
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324
 )


### PR DESCRIPTION
…syscall()

The project used Go has Incorrect Privilege Reporting in syscall. When called with a non-zero flags parameter, the Faccessat function could incorrectly report that a file is accessible. The `syscall.Faccessat` function checks whether the calling process can access a file. `Faccessat` contains a bug where it checks a file's group permission bits if the process's user is a member of the process's group rather than a member of the file's group.

```diff
- if uint32(gid) == st.Gid || isGroupMember(gid) { 
```
```
	var fmode uint32
	if uint32(uid) == st.Uid {
		fmode = (st.Mode >> 6) & 7
	} else {
		var gid int
		if flags&_AT_EACCESS != 0 {
			gid = Getegid()
		} else {
			gid = Getgid()
		}

		if uint32(gid) == st.Gid || isGroupMember(gid) { // <-- this should be isGroupMember(st.Gid), not gid
			fmode = (st.Mode >> 3) & 7
		} else {
			fmode = st.Mode & 7
		}
	}
```
Since a process's user is usually a member of the process's group, this causes Faccessat to usually check a file's group permissions even if the process's user is not a member of the file's group.

**Impact:**
CWE-269
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N`