### PR TITLE
Fix debian 12 install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased](https://github.com/digitalocean/droplet-agent/tree/HEAD)
 
+## [1.2.6](https://github.com/digitalocean/droplet-agent/tree/1.2.6) (2023-09-20)
+### Updated
+- Switched to go 1.21
+- Upgraded all modules
+- Fix installation on Debian 12
+
+### Related PRs
+- Update go and modules [\#101](https://github.com/digitalocean/droplet-agent/pull/101)
+- Fix debian 12 install [\#102](https://github.com/digitalocean/droplet-agent/pull/102)
+
 ## [1.2.5](https://github.com/digitalocean/droplet-agent/tree/1.2.5) (2023-02-28)
 ### Updated
 - Use Lshortfile flag when using syslog

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -2,4 +2,4 @@
 
 package config
 
-const version = "v1.2.5"
+const version = "v1.2.6"

--- a/packaging/scripts/install.sh
+++ b/packaging/scripts/install.sh
@@ -166,6 +166,10 @@ install_apt() (
 	EOF
 
   echo "Installing droplet-agent"
+  # TODO:
+  #  replace the `apt-get -qq update` with
+  # `apt-get -qq update -o Dir::Etc::SourceParts=/dev/null -o APT::Get::List-Cleanup=no -o Dir::Etc::SourceList="sources.list.d/droplet-agent.list"`
+  #  once dependency on crond is gone.
   apt-get -qq update
   apt-get -qq --fix-missing install -y droplet-agent droplet-agent-keyring
 )

--- a/packaging/scripts/install.sh
+++ b/packaging/scripts/install.sh
@@ -166,8 +166,8 @@ install_apt() (
 	EOF
 
   echo "Installing droplet-agent"
-  apt-get -qq update -o Dir::Etc::SourceParts=/dev/null -o APT::Get::List-Cleanup=no -o Dir::Etc::SourceList="sources.list.d/droplet-agent.list"
-  apt-get -qq install --fix-missing -y droplet-agent droplet-agent-keyring
+  apt-get -qq update
+  apt-get -qq --fix-missing install -y droplet-agent droplet-agent-keyring
 )
 
 install_yum() (

--- a/packaging/scripts/install.sh
+++ b/packaging/scripts/install.sh
@@ -167,7 +167,7 @@ install_apt() (
 
   echo "Installing droplet-agent"
   apt-get -qq update -o Dir::Etc::SourceParts=/dev/null -o APT::Get::List-Cleanup=no -o Dir::Etc::SourceList="sources.list.d/droplet-agent.list"
-  apt-get -qq install -y droplet-agent droplet-agent-keyring
+  apt-get -qq install --fix-missing -y droplet-agent droplet-agent-keyring
 )
 
 install_yum() (


### PR DESCRIPTION
Force a global `apt-get update` prior to installing agent, also add `--fix-missing` flag. W/ this changes the `404` errors happening on Debian 12 while installing crond should be fixed. 