### PR TITLE
Explicitly disable CGO when building binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased](https://github.com/digitalocean/droplet-agent/tree/HEAD)
 
+
+## [1.2.7](https://github.com/digitalocean/droplet-agent/tree/1.2.7) (2023-09-20)
+### Updated
+- Explicitly disable CGO when building the agent binary
+
+### Related PRs
+- Explicitly disable CGO when building binary [\#104](https://github.com/digitalocean/droplet-agent/pull/104)
+
 ## [1.2.6](https://github.com/digitalocean/droplet-agent/tree/1.2.6) (2023-09-20)
 ### Updated
 - Switched to go 1.21

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ go = docker run --platform linux/amd64 --rm -i \
 	-e "GOOS=$(GOOS)" \
 	-e "GOARCH=$(GOARCH)" \
 	-e "GOCACHE=$(CURDIR)/target/.cache/go" \
+	-e "CGO_ENABLED=0" \
 	-v "$(CURDIR):$(CURDIR)" \
 	-w "$(CURDIR)" \
 	$(go_docker_linux) \
@@ -43,6 +44,7 @@ go = GOOS=$(GOOS) \
      GOARCH=$(GOARCH) \
      GO111MODULE=on \
      GOFLAGS=-mod=vendor \
+     CGO_ENABLED=0 \
      GOCACHE=$(CURDIR)/target/.cache/go \
      $(shell which go)
 endif

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -2,4 +2,4 @@
 
 package config
 
-const version = "v1.2.6"
+const version = "v1.2.7"


### PR DESCRIPTION
What happened:
After we upgraded to go 1.21 (from go 1.16) to build the droplet-agent, the binary started to crash on some of the droplets with error message `/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found`.  (a report can be found here:https://github.com/digitalocean/droplet-agent/issues/103)

Root cause:
- Starting in Go 1.20, c tool chain is no longer statically linked to the go binary. Go binaries now need to manually have the C libraries properly linked.
- Although we are not directly using CGO in this codebase, some standard libraries (net, os/user etc) that we use may have the cgo implementation chosen when building the binary, if the building environment has C tool chains available.
- While cgo is disabled by default starting from Go 1.20, it may still be enabled if the building environment has C tool chain available, unless explicitly disabled by setting the CGO_ENABLED flag

Related Links:
- https://github.com/golang/go/issues/58550
- https://go.dev/doc/go1.20#cgo


Thanks @iosonogio for reporting this