### PR TITLE
Debian: Depend on cron-daemon instead of cron

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ $(deb_package): $(base_linux_package)
 		--verbose \
 		--input-type deb \
 		--force \
-		--depends cron \
+		--depends cron-daemon \
 		-p $@ \
 		$<
 	# print information about the compiled deb package


### PR DESCRIPTION
Allows users to use their [choice of cron implementation](https://packages.debian.org/sid/cron-daemon) (eg. systemd-cron) on Debian.
I don't use any distro that uses RPM packages so I did not touch the RPM side of things.
I've tested this on a Debian Testing droplet using `systemd-cron` as my cron daemon of choice and it worked.

A workaround for #48

Reference: digitalocean/do-agent#130

