### PR TITLE
ssh key handle new lines

### DIFF
--- a/internal/metadata/ssh_key_parser.go
+++ b/internal/metadata/ssh_key_parser.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/digitalocean/droplet-agent/internal/sysaccess"
 	"regexp"
 	"strings"
+
+	"github.com/digitalocean/droplet-agent/internal/sysaccess"
 )
 
 const (
@@ -52,7 +53,7 @@ func (p *SSHKeyParser) FromDOTTYKey(key string) (*sysaccess.SSHKey, error) {
 	ret := &sysaccess.SSHKey{
 		Type: sysaccess.SSHKeyTypeDOTTY,
 	}
-	if err := json.Unmarshal([]byte(key), ret); err != nil {
+	if err := json.Unmarshal([]byte(strings.Trim(key, " \t\r\n")), ret); err != nil {
 		return nil, fmt.Errorf("%w:invalid key", err)
 	}
 	return ret, nil

--- a/internal/metadata/ssh_key_parser.go
+++ b/internal/metadata/ssh_key_parser.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package metadata
 
 import (

--- a/internal/metadata/ssh_key_parser.go
+++ b/internal/metadata/ssh_key_parser.go
@@ -28,14 +28,23 @@ func NewSSHKeyParser() *SSHKeyParser {
 	}
 }
 
+func containsNewlineOrEncodedNewline(s string) bool {
+	return strings.Contains(s, "\n") ||
+		strings.Contains(s, "\r") ||
+		strings.Contains(s, "%0A") ||
+		strings.Contains(s, "%0D") ||
+		strings.Contains(s, "%0a") ||
+		strings.Contains(s, "%0d")
+}
+
 // FromPublicKey parses a string public key and attempts to convert it to a SSHKey object
 func (p *SSHKeyParser) FromPublicKey(key string) (*sysaccess.SSHKey, error) {
 	ret := &sysaccess.SSHKey{
 		PublicKey: strings.Trim(key, " \t\r\n"),
 		Type:      sysaccess.SSHKeyTypeDroplet,
 	}
-	if strings.Contains(ret.PublicKey, "\n") || strings.Contains(ret.PublicKey, "\r") {
-		return nil, errors.New("invalid public key: contains newline characters")
+	if containsNewlineOrEncodedNewline(ret.PublicKey) {
+		return nil, errors.New("invalid public key: contains newline or encoded newline characters")
 	}
 	match := p.pubKeyOSUserRegex.FindAllStringSubmatch(key, -1)
 	if len(match) != 0 {
@@ -61,8 +70,8 @@ func (p *SSHKeyParser) FromDOTTYKey(key string) (*sysaccess.SSHKey, error) {
 	if err := json.Unmarshal([]byte(strings.Trim(key, " \t\r\n")), ret); err != nil {
 		return nil, fmt.Errorf("%w:invalid key", err)
 	}
-	if strings.Contains(ret.PublicKey, "\n") || strings.Contains(ret.PublicKey, "\r") {
-		return nil, errors.New("invalid public key: contains newline characters")
+	if containsNewlineOrEncodedNewline(ret.PublicKey) {
+		return nil, errors.New("invalid public key: contains newline or encoded newline characters")
 	}
 	return ret, nil
 }

--- a/internal/metadata/ssh_key_parser.go
+++ b/internal/metadata/ssh_key_parser.go
@@ -32,6 +32,9 @@ func (p *SSHKeyParser) FromPublicKey(key string) (*sysaccess.SSHKey, error) {
 		PublicKey: strings.Trim(key, " \t\r\n"),
 		Type:      sysaccess.SSHKeyTypeDroplet,
 	}
+	if strings.Contains(ret.PublicKey, "\n") || strings.Contains(ret.PublicKey, "\r") {
+		return nil, errors.New("invalid public key: contains newline characters")
+	}
 	match := p.pubKeyOSUserRegex.FindAllStringSubmatch(key, -1)
 	if len(match) != 0 {
 		// trying to find "-os_user" flag from the key
@@ -55,6 +58,9 @@ func (p *SSHKeyParser) FromDOTTYKey(key string) (*sysaccess.SSHKey, error) {
 	}
 	if err := json.Unmarshal([]byte(strings.Trim(key, " \t\r\n")), ret); err != nil {
 		return nil, fmt.Errorf("%w:invalid key", err)
+	}
+	if strings.Contains(ret.PublicKey, "\n") || strings.Contains(ret.PublicKey, "\r") {
+		return nil, errors.New("invalid public key: contains newline characters")
 	}
 	return ret, nil
 }

--- a/internal/metadata/ssh_key_parser_test.go
+++ b/internal/metadata/ssh_key_parser_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package metadata
 
 import (

--- a/internal/metadata/ssh_key_parser_test.go
+++ b/internal/metadata/ssh_key_parser_test.go
@@ -2,9 +2,10 @@ package metadata
 
 import (
 	"fmt"
-	"github.com/digitalocean/droplet-agent/internal/sysaccess"
 	"reflect"
 	"testing"
+
+	"github.com/digitalocean/droplet-agent/internal/sysaccess"
 )
 
 func TestSSHKeyParser_FromPublicKey(t *testing.T) {
@@ -62,6 +63,18 @@ func TestSSHKeyParser_FromPublicKey(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"should reject key with newline",
+			"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHRjqHzBANlihrvlhyecJecbR4yV5ufOgl9fllxDFpDGMMDd6Pb+ypR/noxmQwa9ik8Z3ki9e1UAIeQ8K5R3kpE=\ncomment",
+			nil,
+			true,
+		},
+		{
+			"should reject key with carriage return",
+			"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHRjqHzBANlihrvlhyecJecbR4yV5ufOgl9fllxDFpDGMMDd6Pb+ypR/noxmQwa9ik8Z3ki9e1UAIeQ8K5R3kpE=\rcomment",
+			nil,
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -102,6 +115,18 @@ func TestSSHKeyParser_FromDOTTYKey(t *testing.T) {
 		{
 			"return error if not valid json",
 			"invalid-json-string",
+			nil,
+			true,
+		},
+		{
+			"should reject DOTTY key with newline",
+			"{\"os_user\":\"root\",\"ssh_key\":\"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHxxGMc7paI72eTQSNoz+e9jxVZjYDsMwfy6MwPgZlzncKjm+QTfgilNEDskWfU8Om4EiOMedhvrDhBfVSbqAoA=\ncomment\",\"actor_email\":\"actor@email.com\",\"ttl\":50}",
+			nil,
+			true,
+		},
+		{
+			"should reject DOTTY key with carriage return",
+			"{\"os_user\":\"root\",\"ssh_key\":\"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHxxGMc7paI72eTQSNoz+e9jxVZjYDsMwfy6MwPgZlzncKjm+QTfgilNEDskWfU8Om4EiOMedhvrDhBfVSbqAoA=\rcomment\",\"actor_email\":\"actor@email.com\",\"ttl\":50}",
 			nil,
 			true,
 		},

--- a/internal/metadata/ssh_key_parser_test.go
+++ b/internal/metadata/ssh_key_parser_test.go
@@ -77,6 +77,30 @@ func TestSSHKeyParser_FromPublicKey(t *testing.T) {
 			nil,
 			true,
 		},
+		{
+			"should reject key with %0A (encoded newline)",
+			"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHRjqHzBANlihrvlhyecJecbR4yV5ufOgl9fllxDFpDGMMDd6Pb+ypR/noxmQwa9ik8Z3ki9e1UAIeQ8K5R3kpE=%0Acomment",
+			nil,
+			true,
+		},
+		{
+			"should reject key with %0D (encoded carriage return)",
+			"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHRjqHzBANlihrvlhyecJecbR4yV5ufOgl9fllxDFpDGMMDd6Pb+ypR/noxmQwa9ik8Z3ki9e1UAIeQ8K5R3kpE=%0Dcomment",
+			nil,
+			true,
+		},
+		{
+			"should reject key with %0a (encoded newline, lowercase)",
+			"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHRjqHzBANlihrvlhyecJecbR4yV5ufOgl9fllxDFpDGMMDd6Pb+ypR/noxmQwa9ik8Z3ki9e1UAIeQ8K5R3kpE=%0acomment",
+			nil,
+			true,
+		},
+		{
+			"should reject key with %0d (encoded carriage return, lowercase)",
+			"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHRjqHzBANlihrvlhyecJecbR4yV5ufOgl9fllxDFpDGMMDd6Pb+ypR/noxmQwa9ik8Z3ki9e1UAIeQ8K5R3kpE=%0dcomment",
+			nil,
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -129,6 +153,30 @@ func TestSSHKeyParser_FromDOTTYKey(t *testing.T) {
 		{
 			"should reject DOTTY key with carriage return",
 			"{\"os_user\":\"root\",\"ssh_key\":\"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHxxGMc7paI72eTQSNoz+e9jxVZjYDsMwfy6MwPgZlzncKjm+QTfgilNEDskWfU8Om4EiOMedhvrDhBfVSbqAoA=\rcomment\",\"actor_email\":\"actor@email.com\",\"ttl\":50}",
+			nil,
+			true,
+		},
+		{
+			"should reject DOTTY key with %0A (encoded newline)",
+			"{\"os_user\":\"root\",\"ssh_key\":\"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHxxGMc7paI72eTQSNoz+e9jxVZjYDsMwfy6MwPgZlzncKjm+QTfgilNEDskWfU8Om4EiOMedhvrDhBfVSbqAoA=%0Acomment\",\"actor_email\":\"actor@email.com\",\"ttl\":50}",
+			nil,
+			true,
+		},
+		{
+			"should reject DOTTY key with %0D (encoded carriage return)",
+			"{\"os_user\":\"root\",\"ssh_key\":\"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHxxGMc7paI72eTQSNoz+e9jxVZjYDsMwfy6MwPgZlzncKjm+QTfgilNEDskWfU8Om4EiOMedhvrDhBfVSbqAoA=%0Dcomment\",\"actor_email\":\"actor@email.com\",\"ttl\":50}",
+			nil,
+			true,
+		},
+		{
+			"should reject DOTTY key with %0a (encoded newline, lowercase)",
+			"{\"os_user\":\"root\",\"ssh_key\":\"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHxxGMc7paI72eTQSNoz+e9jxVZjYDsMwfy6MwPgZlzncKjm+QTfgilNEDskWfU8Om4EiOMedhvrDhBfVSbqAoA=%0acomment\",\"actor_email\":\"actor@email.com\",\"ttl\":50}",
+			nil,
+			true,
+		},
+		{
+			"should reject DOTTY key with %0d (encoded carriage return, lowercase)",
+			"{\"os_user\":\"root\",\"ssh_key\":\"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHxxGMc7paI72eTQSNoz+e9jxVZjYDsMwfy6MwPgZlzncKjm+QTfgilNEDskWfU8Om4EiOMedhvrDhBfVSbqAoA=%0dcomment\",\"actor_email\":\"actor@email.com\",\"ttl\":50}",
 			nil,
 			true,
 		},


### PR DESCRIPTION
- SSH key parsing now rejects any keys containing:
  - Literal newlines (`\n`) or carriage returns (`\r`)
  - URL-encoded newlines/carriage returns (`%0A`, `%0D`, `%0a`, `%0d`)
- Centralized the sanitization logic in a helper function for maintainability.
- Added unit tests to ensure all disallowed newline forms are properly rejected.