### PR TITLE
Emit logs to journalctl

### DIFF
--- a/packaging/scripts/after_install.sh
+++ b/packaging/scripts/after_install.sh
@@ -42,7 +42,7 @@ patch_updates() {
 
   cat <<-EOF >"${CRON}"
 	#!/bin/sh
-	/bin/bash ${script} >/var/log/droplet-agent.update.log 2>&1
+	/bin/bash ${script} 2>&1
 	EOF
 
   chmod +x "${CRON}"


### PR DESCRIPTION
Remove output redirection from the update log command.

logs to be available at `journalctl -u cron.service` including timestamp

I don't have a setup to validate.

Alternate implementation might be to use `>>` (append) redirection

#127 