### PR TITLE
dont bother checking first

### DIFF
--- a/packaging/scripts/after_install.sh
+++ b/packaging/scripts/after_install.sh
@@ -48,8 +48,8 @@ remove_install_retry_timer() {
 }
 
 remove_legacy_cron() {
-  [ -f "${LEGACY_CRON}" ] && rm -f "${LEGACY_CRON}"
-  [ -f "${LEGACY_RETRY_CRON}" ] && rm -f "${LEGACY_RETRY_CRON}"
+  rm -f "${LEGACY_CRON}"
+  rm -f "${LEGACY_RETRY_CRON}"
 }
 
 main

--- a/packaging/scripts/after_install.sh
+++ b/packaging/scripts/after_install.sh
@@ -39,8 +39,8 @@ configure_updates() {
 }
 
 remove_install_retry_timer() {
-  systemctl stop "${INSTALL_RETRY_TIMER}" || true
-  systemctl disable "${INSTALL_RETRY_TIMER}" || true
+  systemctl stop "${INSTALL_RETRY_TIMER}" >/dev/null 2>&1 || true
+  systemctl disable "${INSTALL_RETRY_TIMER}" >/dev/null 2>&1 || true
   rm -f \
     "/etc/systemd/system/${INSTALL_RETRY_TIMER}" \
     "/etc/systemd/system/${INSTALL_RETRY_SERVICE}" \

--- a/packaging/scripts/after_remove.sh
+++ b/packaging/scripts/after_remove.sh
@@ -51,8 +51,8 @@ clean_systemd() {
 }
 
 remove_legacy_cron() {
-	[ -f "${LEGACY_CRON}" ] && rm -f "${LEGACY_CRON}"
-	[ -f "${LEGACY_RETRY_CRON}" ] && rm -f "${LEGACY_RETRY_CRON}"
+	rm -f "${LEGACY_CRON}"
+	rm -f "${LEGACY_RETRY_CRON}"
 }
 
 main

--- a/packaging/scripts/after_remove.sh
+++ b/packaging/scripts/after_remove.sh
@@ -39,8 +39,8 @@ clean_systemd() {
 	echo "Cleaning up systemd scripts"
 	systemctl stop "${UPDATE_TIMER}" || true
 	systemctl disable "${UPDATE_TIMER}" || true
-	systemctl stop "${INSTALL_RETRY_TIMER}" || true
-	systemctl disable "${INSTALL_RETRY_TIMER}" || true
+	systemctl stop "${INSTALL_RETRY_TIMER}" >/dev/null 2>&1 || true
+	systemctl disable "${INSTALL_RETRY_TIMER}" >/dev/null 2>&1 || true
 	systemctl stop ${SVC_NAME} || true
 	systemctl disable ${SVC_NAME}.service || true
 	systemctl daemon-reload || true

--- a/packaging/scripts/install.sh
+++ b/packaging/scripts/install.sh
@@ -146,7 +146,7 @@ remove_retry_install() {
 }
 
 remove_legacy_retry_cron() {
-  [ -f "${LEGACY_RETRY_CRON}" ] && rm -f "${LEGACY_RETRY_CRON}"
+  rm -f "${LEGACY_RETRY_CRON}"
 }
 
 script_cleanup() {

--- a/packaging/scripts/install.sh
+++ b/packaging/scripts/install.sh
@@ -88,8 +88,8 @@ patch_retry_install() {
   fi
 
   remove_legacy_retry_cron
-  systemctl stop "${RETRY_INSTALL_TIMER}" || true
-  systemctl disable "${RETRY_INSTALL_TIMER}" || true
+  systemctl stop "${RETRY_INSTALL_TIMER}" >/dev/null 2>&1 || true
+  systemctl disable "${RETRY_INSTALL_TIMER}" >/dev/null 2>&1 || true
   mkdir -p "${RETRY_INSTALL_DIR}"
 
   cat <<'EOF' >"${RETRY_INSTALL_SCRIPT}"
@@ -137,8 +137,8 @@ EOF
 
 remove_retry_install() {
   if command -v systemctl >/dev/null 2>&1; then
-    systemctl stop "${RETRY_INSTALL_TIMER}" || true
-    systemctl disable "${RETRY_INSTALL_TIMER}" || true
+    systemctl stop "${RETRY_INSTALL_TIMER}" >/dev/null 2>&1 || true
+    systemctl disable "${RETRY_INSTALL_TIMER}" >/dev/null 2>&1 || true
     systemctl daemon-reload || true
   fi
   rm -f "${RETRY_INSTALL_SERVICE_FILE}" "${RETRY_INSTALL_TIMER_FILE}" "${RETRY_INSTALL_SCRIPT}"


### PR DESCRIPTION
no need to check for legacy files existing first... rm -f will exit zero either way, where the file check itself won't.

the e2e upgrade fleet failed without this due to not having a retry cron present.